### PR TITLE
Feature/258 Configured directories that dont exist

### DIFF
--- a/src/checker/check_language_test.go
+++ b/src/checker/check_language_test.go
@@ -273,6 +273,33 @@ func Test_check_language_src_files(t *testing.T) {
 				model.ErrorCheckPoint("some error"),
 			},
 		},
+		{
+			"unreachable directory error and no matching file", "xxx",
+			language.NewFakeLanguage("").WithAllSrcFiles(
+				func() ([]string, error) {
+					err := language.UnreachableDirectoryError{}
+					err.Add("dir1")
+					return nil, &err
+				}),
+			[]model.CheckPoint{
+				model.WarningCheckPoint("cannot access source directory dir1"),
+				model.WarningCheckPoint("no matching source file found"),
+			},
+		},
+		{
+			"unreachable directory error and one matching file", "xxx",
+			language.NewFakeLanguage("").WithAllSrcFiles(
+				func() ([]string, error) {
+					err := language.UnreachableDirectoryError{}
+					err.Add("dir1")
+					return []string{"src-file1"}, &err
+				}),
+			[]model.CheckPoint{
+				model.WarningCheckPoint("cannot access source directory dir1"),
+				model.OkCheckPoint("matching source files found:"),
+				model.OkCheckPoint("- src-file1"),
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -428,6 +455,33 @@ func Test_check_language_test_files(t *testing.T) {
 				}),
 			[]model.CheckPoint{
 				model.ErrorCheckPoint("some error"),
+			},
+		},
+		{
+			"unreachable directory error and no matching file", "xxx",
+			language.NewFakeLanguage("").WithAllTestFiles(
+				func() ([]string, error) {
+					err := language.UnreachableDirectoryError{}
+					err.Add("dir1")
+					return nil, &err
+				}),
+			[]model.CheckPoint{
+				model.WarningCheckPoint("cannot access test directory dir1"),
+				model.WarningCheckPoint("no matching test file found"),
+			},
+		},
+		{
+			"unreachable directory error and one matching file", "xxx",
+			language.NewFakeLanguage("").WithAllTestFiles(
+				func() ([]string, error) {
+					err := language.UnreachableDirectoryError{}
+					err.Add("dir1")
+					return []string{"test-file1"}, &err
+				}),
+			[]model.CheckPoint{
+				model.WarningCheckPoint("cannot access test directory dir1"),
+				model.OkCheckPoint("matching test files found:"),
+				model.OkCheckPoint("- test-file1"),
 			},
 		},
 	}

--- a/src/engine/tcr.go
+++ b/src/engine/tcr.go
@@ -427,12 +427,18 @@ func (tcr *TCREngine) fromBirthTillDeath(
 }
 
 func (tcr *TCREngine) waitForChange(interrupt <-chan bool) bool {
+	languageDirs := tcr.language.DirsToWatch(tcr.sourceTree.GetBaseDir())
+	existingDirs, err := language.ExistingDirsIn(languageDirs)
+	if err != nil {
+		tcr.handleError(err, true, status.OtherError)
+	}
 	report.PostInfo("Going to sleep until something interesting happens")
 	// We need to wait a bit to make sure the file watcher
 	// does not get triggered again following a revert operation
 	time.Sleep(tcr.fsWatchRearmDelay)
+
 	return tcr.sourceTree.Watch(
-		tcr.language.DirsToWatch(tcr.sourceTree.GetBaseDir()),
+		existingDirs,
 		tcr.language.IsLanguageFile,
 		interrupt)
 }

--- a/src/engine/tcr.go
+++ b/src/engine/tcr.go
@@ -681,7 +681,7 @@ func (tcr *TCREngine) VCSPush() {
 	}
 }
 
-// reportFileStats traces summary information obout the source and test files and directories
+// reportFileStats traces summary information about the source and test files and directories
 func (tcr *TCREngine) reportFileStats() {
 	srcFileCount := countFiles("source", tcr.language.AllSrcFiles)
 	testFileCount := countFiles("test", tcr.language.AllTestFiles)

--- a/src/language/file_tree_filter.go
+++ b/src/language/file_tree_filter.go
@@ -89,20 +89,21 @@ func (treeFilter FileTreeFilter) matches(p string, baseDir string) bool {
 
 func (treeFilter FileTreeFilter) findAllMatchingFiles(baseDir string) (files []string, err error) {
 	for _, dir := range treeFilter.Directories {
-		err := afero.Walk(appFS, filepath.Join(baseDir, dir), func(path string, fi os.FileInfo, err error) error {
-			if err != nil {
-				return errors.New("something wrong with " + path)
-			}
-			if fi.IsDir() {
+		err := afero.Walk(appFS, filepath.Join(baseDir, dir),
+			func(path string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return errors.New("something wrong with " + path + err.Error())
+				}
+				if fi.IsDir() {
+					return nil
+				}
+				// If the filename matches the file pattern, we add it to the list of files
+				if treeFilter.matches(path, baseDir) {
+					files = append(files, path)
+					return err
+				}
 				return nil
-			}
-			// If the filename matches the file pattern, we add it to the list of files
-			if treeFilter.matches(path, baseDir) {
-				files = append(files, path)
-				return err
-			}
-			return nil
-		})
+			})
 		if err != nil {
 			return nil, err
 		}

--- a/src/language/file_tree_filter.go
+++ b/src/language/file_tree_filter.go
@@ -53,8 +53,8 @@ func (e *UnreachableDirectoryError) DirList() []string {
 	return e.dirs
 }
 
-// add adds directories to the list of unreachable directories
-func (e *UnreachableDirectoryError) add(dir ...string) {
+// Add adds directories to the list of unreachable directories
+func (e *UnreachableDirectoryError) Add(dir ...string) {
 	e.dirs = append(e.dirs, dir...)
 }
 
@@ -123,7 +123,7 @@ func (ftf FileTreeFilter) findAllMatchingFiles(baseDir string) (files []string, 
 	for _, dir := range ftf.Directories {
 		matchingFiles, err := ftf.findMatchingFilesInDir(baseDir, dir)
 		if err != nil {
-			dirErr.add(filepath.Join(baseDir, dir))
+			dirErr.Add(filepath.Join(baseDir, dir))
 			continue
 		}
 		files = append(files, matchingFiles...)

--- a/src/language/file_tree_filter_test.go
+++ b/src/language/file_tree_filter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Murex
+Copyright (c) 2023 Murex
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -121,4 +121,38 @@ func Test_find_all_matching_files_with_wrong_base_dir(t *testing.T) {
 	filter := AFileTreeFilter(WithDirectory("src"), WithPattern(".*\\.ext"))
 	_, err := filter.findAllMatchingFiles("wrong-dir")
 	assert.Error(t, err)
+	assert.Equal(t, &UnreachableDirectoryError{dirs: []string{filepath.Join("wrong-dir", "src")}}, err)
+}
+
+func Test_unreachable_directory_error(t *testing.T) {
+	tests := []struct {
+		desc     string
+		dirs     []string
+		expected string
+	}{
+		{
+			"no directory",
+			nil,
+			""},
+		{
+			"one directory",
+			[]string{"dir1"},
+			"cannot access directory: dir1\n",
+		},
+		{
+			"multiple directories",
+			[]string{"dir1", "dir2"},
+			"cannot access directory: dir1\n" +
+				"cannot access directory: dir2\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			e := UnreachableDirectoryError{}
+			e.add(test.dirs...)
+			assert.Equal(t, test.dirs, e.DirList())
+			assert.Equal(t, test.expected, e.Error())
+		})
+	}
 }

--- a/src/language/file_tree_filter_test.go
+++ b/src/language/file_tree_filter_test.go
@@ -150,7 +150,7 @@ func Test_unreachable_directory_error(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			e := UnreachableDirectoryError{}
-			e.add(test.dirs...)
+			e.Add(test.dirs...)
 			assert.Equal(t, test.dirs, e.DirList())
 			assert.Equal(t, test.expected, e.Error())
 		})

--- a/src/language/filesystem.go
+++ b/src/language/filesystem.go
@@ -33,16 +33,17 @@ func init() {
 	appFS = afero.NewOsFs()
 }
 
-func existingDirsIn(dirs []string) ([]string, error) {
-	kept := make([]string, 0)
+// ExistingDirsIn returns the list of directories that actually exist on the filesystem
+// out of a list of candidate directories
+func ExistingDirsIn(dirs []string) (existing []string, err error) {
 	for _, dir := range dirs {
 		exists, err := afero.DirExists(appFS, dir)
 		if err != nil {
 			return nil, err
 		}
 		if exists {
-			kept = append(kept, dir)
+			existing = append(existing, dir)
 		}
 	}
-	return kept, nil
+	return existing, nil
 }

--- a/src/language/filesystem.go
+++ b/src/language/filesystem.go
@@ -22,11 +22,27 @@ SOFTWARE.
 
 package language
 
-import "github.com/spf13/afero"
+import (
+	"github.com/spf13/afero"
+)
 
 // appFS is the singleton referring to the filesystem being used
 var appFS afero.Fs
 
 func init() {
 	appFS = afero.NewOsFs()
+}
+
+func existingDirsIn(dirs []string) ([]string, error) {
+	kept := make([]string, 0)
+	for _, dir := range dirs {
+		exists, err := afero.DirExists(appFS, dir)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			kept = append(kept, dir)
+		}
+	}
+	return kept, nil
 }

--- a/src/language/filesystem_test.go
+++ b/src/language/filesystem_test.go
@@ -51,7 +51,7 @@ func Test_existing_dirs_in(t *testing.T) {
 		{
 			"one missing dir",
 			[]string{missing},
-			[]string{},
+			nil,
 			nil,
 		},
 		{
@@ -63,7 +63,7 @@ func Test_existing_dirs_in(t *testing.T) {
 		{
 			"one existing file",
 			[]string{existingFile},
-			[]string{},
+			nil,
 			nil,
 		},
 	}
@@ -74,7 +74,7 @@ func Test_existing_dirs_in(t *testing.T) {
 			_ = appFS.MkdirAll(existing, os.ModeDir)
 			_ = afero.WriteFile(appFS, existingFile, []byte("some contents"), 0644)
 
-			result, err := existingDirsIn(test.input)
+			result, err := ExistingDirsIn(test.input)
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expected, result)
 		})

--- a/src/language/filesystem_test.go
+++ b/src/language/filesystem_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2023 Murex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package language
+
+import (
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_existing_dirs_in(t *testing.T) {
+	baseDir := filepath.Join("base-dir")
+	existing := filepath.Join(baseDir, "existing")
+	missing := filepath.Join(baseDir, "missing")
+	existingFile := filepath.Join(baseDir, "existing-file")
+
+	tests := []struct {
+		desc        string
+		input       []string
+		expected    []string
+		expectedErr error
+	}{
+		{
+			"one existing dir",
+			[]string{existing},
+			[]string{existing},
+			nil,
+		},
+		{
+			"one missing dir",
+			[]string{missing},
+			[]string{},
+			nil,
+		},
+		{
+			"one existing and one missing dir",
+			[]string{existing, missing},
+			[]string{existing},
+			nil,
+		},
+		{
+			"one existing file",
+			[]string{existingFile},
+			[]string{},
+			nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			appFS = afero.NewMemMapFs()
+			_ = appFS.MkdirAll(existing, os.ModeDir)
+			_ = afero.WriteFile(appFS, existingFile, []byte("some contents"), 0644)
+
+			result, err := existingDirsIn(test.input)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Description:
This feature allows to run TCR even if some of the configured source and/or test directories cannot be reached on the filesystem.

Additional changes and improvements:
- Displays at startup a warning per unreachable directory
- Displays at startup the number of matching source and test files found, or a warning otherwise 
- Displays a warning instead of an error per unreachable directory when running `tcr check`

Fixes #258 

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [x] New feature

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
