### PR TITLE
Feature/timeout notification

### DIFF
--- a/src/timer/mob_turn_countdown.go
+++ b/src/timer/mob_turn_countdown.go
@@ -50,7 +50,8 @@ func NewMobTurnCountdown(mode runmode.RunMode, timeout time.Duration) *PeriodicR
 				case InterruptEvent:
 					report.PostTimerWithEmphasis(messagePrefix, "Stopping countdown after ", fmtDuration(ctx.elapsed))
 				case TimeoutEvent:
-					report.PostWarning(messagePrefix, "Time's up. Time to rotate! You are ", fmtDuration(ctx.remaining.Abs()), " over!")
+					report.PostWarning(messagePrefix, "Time's up. Time to rotate! You are ",
+						fmtDuration(ctx.remaining.Abs()), " over!")
 				}
 			},
 		)

--- a/src/timer/mob_turn_countdown.go
+++ b/src/timer/mob_turn_countdown.go
@@ -50,7 +50,7 @@ func NewMobTurnCountdown(mode runmode.RunMode, timeout time.Duration) *PeriodicR
 				case InterruptEvent:
 					report.PostTimerWithEmphasis(messagePrefix, "Stopping countdown after ", fmtDuration(ctx.elapsed))
 				case TimeoutEvent:
-					report.PostTimerWithEmphasis(messagePrefix, "Time's up. Time to rotate!")
+					report.PostWarning(messagePrefix, "Time's up. Time to rotate! You have ", fmtDuration(ctx.remaining.Abs()), " over!")
 				}
 			},
 		)
@@ -96,8 +96,8 @@ func ReportCountDownStatus(t *PeriodicReminder) {
 			report.PostInfo("Mob Timer: ",
 				fmtDuration(t.GetElapsedTime()), " done, ",
 				fmtDuration(t.GetRemainingTime()), " to go")
-		case StoppedAfterTimeOut:
-			report.PostInfo("Mob Timer has timed out")
+		case AfterTimeOut:
+			report.PostWarning("Mob Timer has timed out ", fmtDuration(t.GetRemainingTime().Abs()), " over!")
 		case StoppedAfterInterruption:
 			report.PostInfo("Mob Timer was interrupted")
 		}

--- a/src/timer/mob_turn_countdown.go
+++ b/src/timer/mob_turn_countdown.go
@@ -50,7 +50,7 @@ func NewMobTurnCountdown(mode runmode.RunMode, timeout time.Duration) *PeriodicR
 				case InterruptEvent:
 					report.PostTimerWithEmphasis(messagePrefix, "Stopping countdown after ", fmtDuration(ctx.elapsed))
 				case TimeoutEvent:
-					report.PostWarning(messagePrefix, "Time's up. Time to rotate! You have ", fmtDuration(ctx.remaining.Abs()), " over!")
+					report.PostWarning(messagePrefix, "Time's up. Time to rotate! You are ", fmtDuration(ctx.remaining.Abs()), " over!")
 				}
 			},
 		)

--- a/src/timer/mob_turn_countdown.go
+++ b/src/timer/mob_turn_countdown.go
@@ -97,7 +97,7 @@ func ReportCountDownStatus(t *PeriodicReminder) {
 				fmtDuration(t.GetElapsedTime()), " done, ",
 				fmtDuration(t.GetRemainingTime()), " to go")
 		case AfterTimeOut:
-			report.PostWarning("Mob Timer has timed out ", fmtDuration(t.GetRemainingTime().Abs()), " over!")
+			report.PostWarning("Mob Timer has timed out: ", fmtDuration(t.GetRemainingTime().Abs()), " over!")
 		case StoppedAfterInterruption:
 			report.PostInfo("Mob Timer was interrupted")
 		}

--- a/src/timer/mob_turn_countdown_test.go
+++ b/src/timer/mob_turn_countdown_test.go
@@ -135,15 +135,18 @@ func Test_report_count_down_status_when_mob_is_started(t *testing.T) {
 	}
 }
 
-func Test_Mob_Turn_Count_down(t *testing.T) {
+func Test_mob_turn_count_down(t *testing.T) {
 	sniffer := report.NewSniffer()
-	reminder := NewMobTurnCountdown(runmode.Mob{}, 0)
-	t.Cleanup(func() {
-		reminder.Stop()
-	})
-	reminder.Start()
-	sniffer.Stop()
-	assert.Equal(t, 1, sniffer.GetMatchCount())
-	assert.Equal(t, "(Mob Timer) Starting 0s countdown", sniffer.GetAllMatches()[0].Text)
+	reminder := NewMobTurnCountdown(runmode.Mob{}, 2*time.Second)
 
+	reminder.Start()
+	time.Sleep(3200 * time.Millisecond)
+	reminder.Stop()
+
+	sniffer.Stop()
+	assert.Equal(t, "(Mob Timer) Starting 2s countdown", sniffer.GetAllMatches()[0].Text)
+	assert.Equal(t, "(Mob Timer) Your turn ends in 1s", sniffer.GetAllMatches()[1].Text)
+	assert.Equal(t, "(Mob Timer) Time's up. Time to rotate! You are 0s over!", sniffer.GetAllMatches()[2].Text)
+	assert.Equal(t, "(Mob Timer) Time's up. Time to rotate! You are 1s over!", sniffer.GetAllMatches()[3].Text)
+	assert.Equal(t, "(Mob Timer) Stopping countdown after 3s", sniffer.GetAllMatches()[4].Text)
 }

--- a/src/timer/mob_turn_countdown_test.go
+++ b/src/timer/mob_turn_countdown_test.go
@@ -23,6 +23,7 @@ SOFTWARE.
 package timer
 
 import (
+	"github.com/murex/tcr/report"
 	"github.com/murex/tcr/runmode"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -83,4 +84,14 @@ func Test_mob_turn_countdown_creation_in_check_runmode(t *testing.T) {
 
 func Test_mob_turn_countdown_creation_in_one_shot_runmode(t *testing.T) {
 	assert.Zero(t, NewMobTurnCountdown(runmode.OneShot{}, defaultTimeout))
+}
+
+func Test_report_count_down_status_when_mob_is_not_started(t *testing.T) {
+
+	sniffer := report.NewSniffer()
+	ReportCountDownStatus(nil)
+	sniffer.Stop()
+	assert.Equal(t, 1, sniffer.GetMatchCount())
+	assert.Equal(t, "Mob Timer is off", sniffer.GetAllMatches()[0].Text)
+
 }

--- a/src/timer/mob_turn_countdown_test.go
+++ b/src/timer/mob_turn_countdown_test.go
@@ -134,3 +134,16 @@ func Test_report_count_down_status_when_mob_is_started(t *testing.T) {
 		})
 	}
 }
+
+func Test_Mob_Turn_Count_down(t *testing.T) {
+	sniffer := report.NewSniffer()
+	reminder := NewMobTurnCountdown(runmode.Mob{}, 0)
+	t.Cleanup(func() {
+		reminder.Stop()
+	})
+	reminder.Start()
+	sniffer.Stop()
+	assert.Equal(t, 1, sniffer.GetMatchCount())
+	assert.Equal(t, "(Mob Timer) Starting 0s countdown", sniffer.GetAllMatches()[0].Text)
+
+}

--- a/src/timer/mob_turn_countdown_test.go
+++ b/src/timer/mob_turn_countdown_test.go
@@ -87,11 +87,34 @@ func Test_mob_turn_countdown_creation_in_one_shot_runmode(t *testing.T) {
 }
 
 func Test_report_count_down_status_when_mob_is_not_started(t *testing.T) {
-
 	sniffer := report.NewSniffer()
 	ReportCountDownStatus(nil)
 	sniffer.Stop()
 	assert.Equal(t, 1, sniffer.GetMatchCount())
 	assert.Equal(t, "Mob Timer is off", sniffer.GetAllMatches()[0].Text)
+}
 
+func Test_report_count_down_status_when_mob_is_started(t *testing.T) {
+	tests := []struct {
+		desc          string
+		state         ReminderState
+		expectedTrace string
+	}{
+		{
+			"timer not started",
+			NotStarted,
+			"Mob Timer is not started",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			sniffer := report.NewSniffer()
+			reminder := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
+			reminder.state = test.state
+			ReportCountDownStatus(reminder)
+			sniffer.Stop()
+			assert.Equal(t, 1, sniffer.GetMatchCount())
+			assert.Equal(t, test.expectedTrace, sniffer.GetAllMatches()[0].Text)
+		})
+	}
 }

--- a/src/timer/mob_turn_countdown_test.go
+++ b/src/timer/mob_turn_countdown_test.go
@@ -105,12 +105,28 @@ func Test_report_count_down_status_when_mob_is_started(t *testing.T) {
 			NotStarted,
 			"Mob Timer is not started",
 		},
+		{
+			"timer running",
+			Running,
+			"Mob Timer: 0s done, 5m to go",
+		},
+		{
+			"after timeout",
+			AfterTimeOut,
+			"Mob Timer has timed out: 5m over!",
+		},
+		{
+			"timer stopped after interruption",
+			StoppedAfterInterruption,
+			"Mob Timer was interrupted",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			sniffer := report.NewSniffer()
-			reminder := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
+			reminder := NewPeriodicReminder(0, 0, func(ctx ReminderContext) {})
 			reminder.state = test.state
+			reminder.startTime = time.Now()
 			ReportCountDownStatus(reminder)
 			sniffer.Stop()
 			assert.Equal(t, 1, sniffer.GetMatchCount())

--- a/src/timer/periodic_reminder.go
+++ b/src/timer/periodic_reminder.go
@@ -114,9 +114,7 @@ func (r *PeriodicReminder) Start() {
 		for {
 			select {
 			case <-r.done:
-				if r.state == StoppedAfterInterruption {
-					r.onEventAction(r.buildEventContext(InterruptEvent, time.Now()))
-				}
+				r.onEventAction(r.buildEventContext(InterruptEvent, time.Now()))
 				return
 			case timestamp := <-r.ticker.C:
 				if r.state == AfterTimeOut {

--- a/src/timer/periodic_reminder.go
+++ b/src/timer/periodic_reminder.go
@@ -147,7 +147,7 @@ func (r *PeriodicReminder) buildEventContext(eventType ReminderEventType, timest
 			elapsed:   0,
 			remaining: r.timeout,
 		}
-	case PeriodicEvent:
+	case PeriodicEvent, TimeoutEvent:
 		elapsed := time.Duration(r.tickCounter+1) * r.tickPeriod
 		ctx = ReminderContext{
 			eventType: eventType,
@@ -165,16 +165,6 @@ func (r *PeriodicReminder) buildEventContext(eventType ReminderEventType, timest
 			timestamp: timestamp,
 			elapsed:   time.Since(r.startTime),
 			remaining: 0,
-		}
-	case TimeoutEvent:
-		elapsed := time.Duration(r.tickCounter+1) * r.tickPeriod
-		ctx = ReminderContext{
-			eventType: eventType,
-			index:     r.tickCounter,
-			indexMax:  r.lastTickIndex,
-			timestamp: timestamp,
-			elapsed:   elapsed,
-			remaining: r.timeout - elapsed,
 		}
 	}
 	return ctx

--- a/src/timer/periodic_reminder.go
+++ b/src/timer/periodic_reminder.go
@@ -176,7 +176,7 @@ func (r *PeriodicReminder) buildEventContext(eventType ReminderEventType, timest
 			indexMax:  r.lastTickIndex,
 			timestamp: timestamp,
 			elapsed:   elapsed,
-			remaining: 0,
+			remaining: r.timeout - elapsed,
 		}
 	}
 	return ctx

--- a/src/timer/periodic_reminder.go
+++ b/src/timer/periodic_reminder.go
@@ -213,7 +213,7 @@ func (r *PeriodicReminder) GetRemainingTime() time.Duration {
 	switch r.state {
 	case NotStarted:
 		return r.timeout
-	case Running:
+	case Running, AfterTimeOut:
 		return r.timeout - time.Since(r.startTime)
 	default:
 		return 0

--- a/src/timer/periodic_reminder_test.go
+++ b/src/timer/periodic_reminder_test.go
@@ -67,7 +67,7 @@ func Test_init_with_non_default_timeout(t *testing.T) {
 	assert.Equal(t, testTimeout, r.timeout)
 }
 
-func Test_ticking_not_stops_after_timeout(t *testing.T) {
+func Test_ticking_does_not_stop_after_timeout(t *testing.T) {
 	r := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
 	r.Start()
 	time.Sleep(testTimeout * 2)
@@ -135,7 +135,7 @@ func Test_stop_reminder_between_1st_and_2nd_tick(t *testing.T) {
 	assert.Equal(t, StoppedAfterInterruption, r.state)
 }
 
-func Test_continue_reminder_after_timeout(t *testing.T) {
+func Test_keep_posting_reminders_after_timeout(t *testing.T) {
 	r := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
 	r.Start()
 	time.Sleep(testTimeout * 2)
@@ -147,7 +147,7 @@ func Test_continue_reminder_after_timeout(t *testing.T) {
 
 // PeriodicReminder tick counter
 
-func Test_can_track_number_of_ticks_fired_continue_after_timeout(t *testing.T) {
+func Test_can_track_number_of_ticks_fired_before_and_after_timeout(t *testing.T) {
 	r := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
 	r.Start()
 	time.Sleep(testTimeout)
@@ -265,7 +265,7 @@ func Test_retrieving_time_elapsed_since_timer_started(t *testing.T) {
 
 // Time remaining until timer ends
 
-func Test_retrieving_time_remaining_while_timer_running(t *testing.T) {
+func Test_retrieving_time_remaining_while_timer_is_running(t *testing.T) {
 	r := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
 	// Before calling Start(), time remaining should stick to timeout
 	assert.Equal(t, testTimeout, r.GetRemainingTime())

--- a/src/timer/periodic_reminder_test.go
+++ b/src/timer/periodic_reminder_test.go
@@ -197,6 +197,7 @@ func Test_callback_function_can_know_timestamp(t *testing.T) {
 	r.Start()
 	time.Sleep(testTimeout * 2)
 	r.Stop()
+	time.Sleep(testTickPeriod)
 	tsEnd := time.Now()
 
 	assert.True(t, tsStart.Before(tsPeriodic[0]))

--- a/src/timer/periodic_reminder_test.go
+++ b/src/timer/periodic_reminder_test.go
@@ -261,19 +261,22 @@ func Test_retrieving_time_elapsed_since_timer_started(t *testing.T) {
 	time.Sleep(testTimeout)
 	// After timeout, the timer should continue running
 	assert.InEpsilon(t, testTimeout, r.GetElapsedTime(), 0.7)
+	r.Stop()
 }
 
 // Time remaining until timer ends
 
-func Test_retrieving_time_remaining_until_timer_ends(t *testing.T) {
+func Test_retrieving_time_remaining_while_timer_running(t *testing.T) {
 	r := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
 	// Before calling Start(), time remaining should stick to timeout
 	assert.Equal(t, testTimeout, r.GetRemainingTime())
 	r.Start()
-	time.Sleep(testTimeout / 2)
 	// While timer is running, total time remaining is timeout - time spent since Start()
+	time.Sleep(testTimeout / 2)
 	assert.InEpsilon(t, testTimeout/2, r.GetRemainingTime(), 0.3)
+
+	// After timeout, time remaining should be negative
 	time.Sleep(testTimeout)
-	// When timer is done, time remaining should be 0
-	assert.Zero(t, r.GetRemainingTime())
+	assert.InEpsilon(t, -testTimeout/2, r.GetRemainingTime(), 0.3)
+	r.Stop()
 }

--- a/src/timer/periodic_reminder_test.go
+++ b/src/timer/periodic_reminder_test.go
@@ -256,13 +256,16 @@ func Test_retrieving_time_elapsed_since_timer_started(t *testing.T) {
 	// Before calling Start(), time elapsed should stick to 0
 	assert.Zero(t, r.GetElapsedTime())
 	r.Start()
-	time.Sleep(testTimeout / 2)
 	// While timer is running, total time elapsed is time spent since Start()
+	time.Sleep(testTimeout / 2)
 	assert.InEpsilon(t, testTimeout/2, r.GetElapsedTime(), 0.3)
-	time.Sleep(testTimeout)
 	// After timeout, the timer should continue running
+	time.Sleep(testTimeout)
 	assert.InEpsilon(t, testTimeout, r.GetElapsedTime(), 0.7)
+	// After stop, we should get the total time spend
+	time.Sleep(testTimeout / 2)
 	r.Stop()
+	assert.InEpsilon(t, testTimeout*2, r.GetElapsedTime(), 0.3)
 }
 
 // Time remaining until timer ends
@@ -275,9 +278,10 @@ func Test_retrieving_time_remaining_while_timer_running(t *testing.T) {
 	// While timer is running, total time remaining is timeout - time spent since Start()
 	time.Sleep(testTimeout / 2)
 	assert.InEpsilon(t, testTimeout/2, r.GetRemainingTime(), 0.3)
-
 	// After timeout, time remaining should be negative
 	time.Sleep(testTimeout)
 	assert.InEpsilon(t, -testTimeout/2, r.GetRemainingTime(), 0.3)
+	// After stop, time remaining should be zero
 	r.Stop()
+	assert.Zero(t, r.GetRemainingTime())
 }

--- a/src/timer/periodic_reminder_test.go
+++ b/src/timer/periodic_reminder_test.go
@@ -150,16 +150,11 @@ func Test_continue_reminder_after_timeout(t *testing.T) {
 func Test_can_track_number_of_ticks_fired_continue_after_timeout(t *testing.T) {
 	r := NewPeriodicReminder(testTimeout, testTickPeriod, func(ctx ReminderContext) {})
 	r.Start()
-	assert.Equal(t, 0, r.tickCounter)
-	time.Sleep(testTickPeriod / 2)
-	assert.Equal(t, 0, r.tickCounter)
-	time.Sleep(testTickPeriod)
-	assert.Equal(t, 1, r.tickCounter)
-	time.Sleep(testTickPeriod)
+	time.Sleep(testTimeout)
 	assert.Equal(t, 2, r.tickCounter)
 	time.Sleep(testTickPeriod)
 	assert.Equal(t, 3, r.tickCounter)
-	assert.Equal(t, AfterTimeOut, r.state)
+	r.Stop()
 }
 
 // PeriodicReminder callback function

--- a/src/timer/periodic_reminder_test.go
+++ b/src/timer/periodic_reminder_test.go
@@ -196,6 +196,7 @@ func Test_callback_function_can_know_timestamp(t *testing.T) {
 	})
 	r.Start()
 	time.Sleep(testTimeout * 2)
+	r.Stop()
 	tsEnd := time.Now()
 
 	assert.True(t, tsStart.Before(tsPeriodic[0]))
@@ -234,6 +235,7 @@ func Test_callback_function_can_know_remaining_time_until_end(t *testing.T) {
 	})
 	r.Start()
 	time.Sleep(testTimeout)
+	r.Stop()
 }
 
 func Test_callback_function_can_know_max_index_value(t *testing.T) {


### PR DESCRIPTION
<!-- If this is your first pull request for this project, please read the contributor docs at:
https://github.com/murex/.github/blob/main/CONTRIBUTING.md. --> 

# Description:
Rather than stopping the timer after the timeout is reached, the TCR will continue the timer and send the timeout notification periodically. This allows the TCR trace to show a warning message periodically with how much time is over.

Fixes #384

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [x] New feature

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
