### PR TITLE
[#568] Bump go version from 1.21 to 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
           cache-dependency-path: src/go.sum
 

--- a/.github/workflows/go_releaser.yml
+++ b/.github/workflows/go_releaser.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
           cache-dependency-path: src/go.sum
       - name: Setup node.js

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -10,7 +10,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [ '1.21' ]
+        go: [ '1.22' ]
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters:
     - structcheck
     - varcheck
 run:
-  go: "1.21"
+  go: "1.22"
   timeout: 5m
 linters-settings:
   gocyclo:

--- a/dev-doc/build.md
+++ b/dev-doc/build.md
@@ -14,7 +14,7 @@ cd TCR
 
 TCR is written in Go. This implies having Go compiler and tools installed on your machine.
 
-Simply follow the instructions provided [here](https://go.dev/). Make sure to install **Go version 1.21** or higher.
+Simply follow the instructions provided [here](https://go.dev/). Make sure to install **Go version 1.22** or higher.
 
 ## Install additional Go tools and utility packages
 

--- a/examples/go-bazel/go.mod
+++ b/examples/go-bazel/go.mod
@@ -1,6 +1,6 @@
 module example/go-bazel
 
-go 1.21
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 

--- a/examples/go-go-tools/go.mod
+++ b/examples/go-go-tools/go.mod
@@ -1,6 +1,6 @@
 module example/go-go-tools
 
-go 1.21
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 

--- a/examples/go-gotestsum/go.mod
+++ b/examples/go-gotestsum/go.mod
@@ -1,6 +1,6 @@
 module example/go-gotestsum
 
-go 1.21
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 

--- a/examples/go-make/go.mod
+++ b/examples/go-make/go.mod
@@ -1,6 +1,6 @@
 module example/go-make
 
-go 1.21
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 

--- a/examples/go.work
+++ b/examples/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.22
 
 use (
 	go-bazel

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.22
 
 use (
 	tcr-doc

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,8 +1,6 @@
 module github.com/murex/tcr
 
-go 1.21
-
-toolchain go1.21.1
+go 1.22
 
 require (
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect

--- a/tcr-doc/go.mod
+++ b/tcr-doc/go.mod
@@ -1,8 +1,6 @@
 module github.com/murex/tcr/tcr-doc
 
-go 1.21
-
-toolchain go1.21.1
+go 1.22
 
 replace github.com/murex/tcr => ../src
 


### PR DESCRIPTION
# Description:
Upgrade of Go build version from 1.21 to 1.22

Fixes #568 

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [ ] New feature
- [x] Toochain

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
