### PR TITLE
Feature/390 real time trace

### DIFF
--- a/src/toolchain/command.go
+++ b/src/toolchain/command.go
@@ -24,8 +24,6 @@ package toolchain
 
 import (
 	"errors"
-	"github.com/codeskyblue/go-sh"
-	"github.com/murex/tcr/report"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,33 +48,6 @@ type (
 		Path      string
 		Arguments []string
 	}
-
-	// CommandStatus is the result status of a Command execution
-	CommandStatus string
-
-	// CommandResult contains the result from running a Command
-	// - Status
-	CommandResult struct {
-		Status CommandStatus
-		Output string
-	}
-)
-
-// Failed indicates is a Command failed
-func (r CommandResult) Failed() bool {
-	return r.Status == CommandStatusFail
-}
-
-// Passed indicates is a Command passed
-func (r CommandResult) Passed() bool {
-	return r.Status == CommandStatusPass
-}
-
-// List of possible values for CommandStatus
-const (
-	CommandStatusPass    CommandStatus = "pass"
-	CommandStatusFail    CommandStatus = "fail"
-	CommandStatusUnknown CommandStatus = "unknown"
 )
 
 // List of possible values for OsName
@@ -127,26 +98,6 @@ func (command Command) runsWithArch(archName ArchName) bool {
 		}
 	}
 	return false
-}
-
-func (command Command) run() (result CommandResult) {
-	result = CommandResult{Status: CommandStatusUnknown, Output: ""}
-	report.PostText(command.asCommandLine())
-
-	session := sh.NewSession().SetDir(GetWorkDir())
-	outputBytes, err := session.Command(command.Path, command.Arguments).CombinedOutput()
-
-	if err == nil {
-		result.Status = CommandStatusPass
-	} else {
-		result.Status = CommandStatusFail
-	}
-
-	if outputBytes != nil {
-		result.Output = string(outputBytes)
-		report.PostText(result.Output)
-	}
-	return result
 }
 
 func (command Command) check() error {

--- a/src/toolchain/command_runner.go
+++ b/src/toolchain/command_runner.go
@@ -91,6 +91,12 @@ func (r *CommandRunner) Run(cmd *Command) (result CommandResult) {
 	errStart := r.command.Start()
 	if errStart != nil {
 		report.PostError("Failed to run command: ", errStart.Error())
+		// We currently return fail status when command cannot be launched.
+		// This is to replicate previous implementation's behaviour where
+		// we could not differentiate between failure to launch and failure from execution.
+		// We could later on use a different return value in this situation,
+		// but we need to ensure first that TCR engine can handle it correctly.
+		result.Status = CommandStatusFail
 		r.command = nil
 		return result
 	}

--- a/src/toolchain/command_runner.go
+++ b/src/toolchain/command_runner.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2024 Murex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package toolchain
+
+import (
+	"bufio"
+	"github.com/murex/tcr/report"
+	"os/exec"
+)
+
+type (
+	// CommandRunner is in charge of managing the lifecycle of a command
+	CommandRunner struct {
+		command *exec.Cmd
+	}
+
+	// CommandStatus is the result status of a Command execution
+	CommandStatus string
+
+	// CommandResult contains the result from running a Command
+	// - Status
+	CommandResult struct {
+		Status CommandStatus
+		Output string
+	}
+)
+
+// Failed indicates is a Command failed
+func (r CommandResult) Failed() bool {
+	return r.Status == CommandStatusFail
+}
+
+// Passed indicates is a Command passed
+func (r CommandResult) Passed() bool {
+	return r.Status == CommandStatusPass
+}
+
+// List of possible values for CommandStatus
+const (
+	CommandStatusPass    CommandStatus = "pass"
+	CommandStatusFail    CommandStatus = "fail"
+	CommandStatusUnknown CommandStatus = "unknown"
+)
+
+// commandRunner singleton instance
+var commandRunner = getCommandRunner()
+
+func getCommandRunner() *CommandRunner {
+	return &CommandRunner{
+		command: nil,
+	}
+}
+
+// Run launches the execution of the provided command
+func (r *CommandRunner) Run(cmd *Command) (result CommandResult) {
+	result = CommandResult{Status: CommandStatusUnknown, Output: ""}
+	report.PostText(cmd.asCommandLine())
+
+	// Prepare the command
+	r.command = exec.Command(cmd.Path, cmd.Arguments...) //nolint:gosec
+	r.command.Dir = GetWorkDir()
+
+	// Allow simultaneous trace and capture of command's stdout and stderr
+	outReader, _ := r.command.StdoutPipe()
+	errReader, _ := r.command.StderrPipe()
+	doneOut, doneErr := make(chan bool), make(chan bool)
+	r.reportCommandTrace(bufio.NewScanner(outReader), doneOut)
+	r.reportCommandTrace(bufio.NewScanner(errReader), doneErr)
+
+	// Start the command asynchronously
+	errStart := r.command.Start()
+	if errStart != nil {
+		report.PostError("Failed to run command: ", errStart.Error())
+		r.command = nil
+		return result
+	}
+
+	// Wait for the command to finish
+	errWait := r.command.Wait()
+	if errWait != nil {
+		result.Status = CommandStatusFail
+	} else {
+		result.Status = CommandStatusPass
+	}
+
+	r.command = nil
+	return result
+}
+
+func (*CommandRunner) reportCommandTrace(scanner *bufio.Scanner, done chan bool) {
+	go func() {
+		for scanner.Scan() {
+			report.PostText(scanner.Text())
+		}
+		done <- true
+	}()
+}

--- a/src/toolchain/command_runner_test.go
+++ b/src/toolchain/command_runner_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2024 Murex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package toolchain
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_command_result_outcome(t *testing.T) {
+
+	testFlags := []struct {
+		status         CommandStatus
+		expectedPassed bool
+		expectedFailed bool
+	}{
+		{"pass", true, false},
+		{"fail", false, true},
+		{"unknown", false, false},
+	}
+	for _, tt := range testFlags {
+		t.Run(fmt.Sprint(tt.status, "_status"), func(t *testing.T) {
+			result := CommandResult{Status: tt.status}
+			assert.Equal(t, tt.expectedPassed, result.Passed())
+			assert.Equal(t, tt.expectedFailed, result.Failed())
+		})
+	}
+}

--- a/src/toolchain/command_test.go
+++ b/src/toolchain/command_test.go
@@ -133,23 +133,3 @@ func Test_a_command_arch_cannot_be_empty(t *testing.T) {
 func Test_a_valid_command_should_have_path_os_and_arch_non_empty(t *testing.T) {
 	assert.NoError(t, ACommand(WithPath("some-path"), WithOs("some-os"), WithArch("some-arch")).check())
 }
-
-func Test_command_result_outcome(t *testing.T) {
-
-	testFlags := []struct {
-		status         CommandStatus
-		expectedPassed bool
-		expectedFailed bool
-	}{
-		{"pass", true, false},
-		{"fail", false, true},
-		{"unknown", false, false},
-	}
-	for _, tt := range testFlags {
-		t.Run(fmt.Sprint(tt.status, "_status"), func(t *testing.T) {
-			result := CommandResult{Status: tt.status}
-			assert.Equal(t, tt.expectedPassed, result.Passed())
-			assert.Equal(t, tt.expectedFailed, result.Failed())
-		})
-	}
-}

--- a/src/toolchain/toolchain.go
+++ b/src/toolchain/toolchain.go
@@ -150,12 +150,14 @@ func (tchn Toolchain) GetTestCommands() []Command {
 
 // RunBuild runs the build with this toolchain
 func (tchn Toolchain) RunBuild() CommandResult {
-	return findCompatibleCommand(tchn.buildCommands).run()
+	cmd := findCompatibleCommand(tchn.buildCommands)
+	return commandRunner.Run(cmd)
 }
 
 // RunTests runs the tests with this toolchain
 func (tchn Toolchain) RunTests() TestCommandResult {
-	result := findCompatibleCommand(tchn.testCommands).run()
+	cmd := findCompatibleCommand(tchn.testCommands)
+	result := commandRunner.Run(cmd)
 	testStats, _ := tchn.parseTestReport()
 	return TestCommandResult{result, testStats}
 }


### PR DESCRIPTION
# Description:
Allows to display toolchain commands execution trace in "real time" (e.g. line per line) instead of dumping the whole trace after commands are completed. This is expected to improve UX, especially to remove the false impression that TCR is hanging, while it's actually waiting for a slow command to terminate.

Fixes #390 

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [ ] New feature
- [x]  Enhancement

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
