### PR TITLE
Add possibility to use a git remote other than "origin"

### DIFF
--- a/doc/tcr.md
+++ b/doc/tcr.md
@@ -20,6 +20,7 @@ tcr [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -h, --help                    help for tcr
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")

--- a/doc/tcr_check.md
+++ b/doc/tcr_check.md
@@ -48,6 +48,7 @@ tcr check [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_config.md
+++ b/doc/tcr_config.md
@@ -26,6 +26,7 @@ tcr config [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_config_reset.md
+++ b/doc/tcr_config_reset.md
@@ -26,6 +26,7 @@ tcr config reset [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_config_save.md
+++ b/doc/tcr_config_save.md
@@ -26,6 +26,7 @@ tcr config save [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_config_show.md
+++ b/doc/tcr_config_show.md
@@ -26,6 +26,7 @@ tcr config show [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_info.md
+++ b/doc/tcr_info.md
@@ -26,6 +26,7 @@ tcr info [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_log.md
+++ b/doc/tcr_log.md
@@ -34,6 +34,7 @@ tcr log [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_mob.md
+++ b/doc/tcr_mob.md
@@ -26,6 +26,7 @@ tcr mob [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_one-shot.md
+++ b/doc/tcr_one-shot.md
@@ -37,6 +37,7 @@ tcr one-shot [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_solo.md
+++ b/doc/tcr_solo.md
@@ -26,6 +26,7 @@ tcr solo [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_stats.md
+++ b/doc/tcr_stats.md
@@ -54,6 +54,7 @@ tcr stats [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/doc/tcr_web.md
+++ b/doc/tcr_web.md
@@ -32,6 +32,7 @@ tcr web [flags]
   -b, --base-dir string         indicate the directory from which TCR is looking for files (default: current directory)
   -c, --config-dir string       indicate the directory where TCR configuration is stored (default: current directory)
   -d, --duration duration       set the duration for role rotation countdown timer
+  -g, --git-remote string       name of the git remote repository to sync with (default: "origin")
   -l, --language string         indicate the programming language to be used by TCR
   -m, --message-suffix string   indicate text to append at the end of TCR commit messages (ex: "[#1234]")
   -o, --polling duration        set VCS polling period when running as navigator

--- a/src/checker/check_git.go
+++ b/src/checker/check_git.go
@@ -98,6 +98,9 @@ func checkGitRemote(_ params.Params) (cp []model.CheckPoint) {
 	}
 
 	if !checkEnv.vcs.IsRemoteEnabled() {
+		if checkEnv.vcs.GetRemoteName() != "" {
+			cp = append(cp, model.WarningCheckPoint("git remote not found: ", checkEnv.vcs.GetRemoteName()))
+		}
 		cp = append(cp, model.OkCheckPoint("git remote is disabled: all operations will be done locally"))
 		return cp
 	}

--- a/src/checker/check_git_test.go
+++ b/src/checker/check_git_test.go
@@ -175,9 +175,10 @@ func Test_check_git_remote(t *testing.T) {
 			"VCS not initialized", nil, []model.CheckPoint{},
 		},
 		{
-			"git remote disabled",
+			"git remote disabled due to undefined remote name",
 			fake.NewVCSFake(fake.Settings{RemoteEnabled: false}),
 			[]model.CheckPoint{
+				model.WarningCheckPoint("git remote not found: vcs-fake-remote-name"),
 				model.OkCheckPoint("git remote is disabled: all operations will be done locally"),
 			},
 		},

--- a/src/checker/runner.go
+++ b/src/checker/runner.go
@@ -99,6 +99,6 @@ func initCheckEnv(p params.Params) {
 	checkEnv.workDir = toolchain.GetWorkDir()
 
 	if checkEnv.sourceTreeErr == nil {
-		checkEnv.vcs, checkEnv.vcsErr = factory.InitVCS(p.VCS, checkEnv.sourceTree.GetBaseDir())
+		checkEnv.vcs, checkEnv.vcsErr = factory.InitVCS(p.VCS, checkEnv.sourceTree.GetBaseDir(), p.GitRemote)
 	}
 }

--- a/src/checker/runner_test.go
+++ b/src/checker/runner_test.go
@@ -35,7 +35,7 @@ import (
 
 func initTestCheckEnv(params params.Params) {
 	// Replace VCS factory initializer in order to use a VCS fake instead of the real thing
-	factory.InitVCS = func(_ string, _ string) (vcs.Interface, error) {
+	factory.InitVCS = func(_ string, _ string, _ string) (vcs.Interface, error) {
 		return fake.NewVCSFake(fake.Settings{}), nil
 	}
 	initCheckEnv(params)

--- a/src/config/param_git_remote.go
+++ b/src/config/param_git_remote.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 Murex
+Copyright (c) 2024 Murex
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,28 +20,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package params
+package config
 
 import (
-	"github.com/murex/tcr/runmode"
-	"time"
+	"github.com/spf13/cobra"
 )
 
-// Params contains the main parameter values that TCR engine is using
-type Params struct {
-	ConfigDir       string
-	BaseDir         string
-	WorkDir         string
-	Language        string
-	Toolchain       string
-	MobTurnDuration time.Duration
-	GitRemote       string
-	AutoPush        bool
-	Variant         string
-	PollingPeriod   time.Duration
-	Mode            runmode.RunMode
-	VCS             string
-	MessageSuffix   string
-	Trace           string
-	PortNumber      int
+// AddGitRemoteParam adds a parameter allowing to specify the name of the git remote repository
+func AddGitRemoteParam(cmd *cobra.Command) *StringParam {
+	param := StringParam{
+		s: paramSettings{
+			viperSettings: viperSettings{
+				enabled: false,
+				keyPath: "",
+				name:    "",
+			},
+			cobraSettings: cobraSettings{
+				name:       "git-remote",
+				shorthand:  "g",
+				usage:      "name of the git remote repository to sync with (default: \"origin\")",
+				persistent: true,
+			},
+		},
+		v: paramValueString{
+			value:        "",
+			defaultValue: "origin",
+		},
+	}
+	param.addToCommand(cmd)
+	return &param
 }

--- a/src/config/tcr_config.go
+++ b/src/config/tcr_config.go
@@ -45,6 +45,7 @@ type TcrConfig struct {
 	Toolchain        *StringParam
 	PollingPeriod    *DurationParam
 	MobTimerDuration *DurationParam
+	GitRemote        *StringParam
 	AutoPush         *BoolParam
 	Variant          *StringParam
 	VCS              *StringParam
@@ -59,6 +60,7 @@ func (c TcrConfig) reset() {
 	c.PollingPeriod.reset()
 	c.MobTimerDuration.reset()
 	c.AutoPush.reset()
+	c.GitRemote.reset()
 	c.Variant.reset()
 	c.VCS.reset()
 	c.MessageSuffix.reset()
@@ -199,6 +201,7 @@ func AddParameters(cmd *cobra.Command, defaultDir string) {
 	Config.Toolchain = AddToolchainParam(cmd)
 	Config.PollingPeriod = AddPollingPeriodParam(cmd)
 	Config.MobTimerDuration = AddMobTimerDurationParam(cmd)
+	Config.GitRemote = AddGitRemoteParam(cmd)
 	Config.AutoPush = AddAutoPushParam(cmd)
 	Config.Variant = AddVariantParam(cmd)
 	Config.VCS = AddVCSParam(cmd)
@@ -217,6 +220,7 @@ func UpdateEngineParams(p *params.Params) {
 	p.Toolchain = Config.Toolchain.GetValue()
 	p.PollingPeriod = Config.PollingPeriod.GetValue()
 	p.AutoPush = Config.AutoPush.GetValue()
+	p.GitRemote = Config.GitRemote.GetValue()
 	p.Variant = Config.Variant.GetValue()
 	p.VCS = Config.VCS.GetValue()
 	p.MessageSuffix = Config.MessageSuffix.GetValue()

--- a/src/engine/tcr.go
+++ b/src/engine/tcr.go
@@ -174,6 +174,7 @@ func (tcr *TCREngine) Init(p params.Params) {
 	tcr.initVCS(p.VCS, p.Trace)
 	tcr.setMessageSuffix(p.MessageSuffix)
 	tcr.vcs.EnableAutoPush(p.AutoPush)
+	tcr.vcs.SetRemoteName(p.GitRemote)
 
 	tcr.SetVariant(p.Variant)
 	tcr.setMobTimerDuration(p.MobTurnDuration)

--- a/src/engine/tcr.go
+++ b/src/engine/tcr.go
@@ -171,10 +171,9 @@ func (tcr *TCREngine) Init(p params.Params) {
 	tcr.handleError(err, true, status.ConfigError)
 	report.PostInfo("Work directory is ", toolchain.GetWorkDir())
 
-	tcr.initVCS(p.VCS, p.Trace)
+	tcr.initVCS(p.VCS, p.GitRemote, p.Trace)
 	tcr.setMessageSuffix(p.MessageSuffix)
 	tcr.vcs.EnableAutoPush(p.AutoPush)
-	tcr.vcs.SetRemoteName(p.GitRemote)
 
 	tcr.SetVariant(p.Variant)
 	tcr.setMobTimerDuration(p.MobTurnDuration)
@@ -241,7 +240,7 @@ func tcrLogsToEvents(tcrLogs vcs.LogItems) (tcrEvents events.TcrEvents) {
 
 func (tcr *TCREngine) queryVCSLogs(p params.Params) vcs.LogItems {
 	tcr.initSourceTree(p)
-	tcr.initVCS(p.VCS, p.Trace)
+	tcr.initVCS(p.VCS, "", p.Trace)
 
 	logs, err := tcr.vcs.Log(isTCRCommitMessage)
 	if err != nil {
@@ -315,14 +314,14 @@ func (tcr *TCREngine) wrapCommitMessages(statusMessage string, event *events.TCR
 	return messages
 }
 
-func (tcr *TCREngine) initVCS(vcsName string, trace string) {
+func (tcr *TCREngine) initVCS(vcsName string, remoteName string, trace string) {
 	if tcr.vcs != nil {
 		return // VCS should be initialized only once
 	}
 	// Set VCS trace flag
 	vcs.SetTrace(trace == "vcs")
 	var err error
-	tcr.vcs, err = factory.InitVCS(vcsName, tcr.sourceTree.GetBaseDir())
+	tcr.vcs, err = factory.InitVCS(vcsName, tcr.sourceTree.GetBaseDir(), remoteName)
 	var unsupportedVCSError *factory.UnsupportedVCSError
 	switch {
 	case errors.As(err, &unsupportedVCSError):

--- a/src/engine/tcr_test.go
+++ b/src/engine/tcr_test.go
@@ -427,6 +427,7 @@ func initTCREngineWithFakesWithFileDiffs(
 			params.WithPollingPeriod(p.PollingPeriod),
 			params.WithRunMode(p.Mode),
 			params.WithVCS(p.VCS),
+			params.WithGitRemote(p.GitRemote),
 			params.WithMessageSuffix(p.MessageSuffix),
 		)
 	}
@@ -434,7 +435,7 @@ func initTCREngineWithFakesWithFileDiffs(
 	tcr := NewTCREngine()
 	// Replace VCS factory initializer in order to use a VCS fake instead of the real thing
 	var vcsFake *fake.VCSFake
-	factory.InitVCS = func(_ string, _ string) (vcs.Interface, error) {
+	factory.InitVCS = func(_ string, _ string, _ string) (vcs.Interface, error) {
 		fakeSettings := fake.Settings{
 			FailingCommands: vcsFailures,
 			ChangedFiles:    fileDiffs,

--- a/src/params/params_test_data_builder.go
+++ b/src/params/params_test_data_builder.go
@@ -39,6 +39,7 @@ func AParamSet(builders ...func(params *Params)) *Params {
 		Toolchain:       "",
 		MobTurnDuration: 0,
 		AutoPush:        false,
+		GitRemote:       "origin",
 		Variant:         "relaxed",
 		PollingPeriod:   0,
 		Mode:            runmode.OneShot{},
@@ -105,6 +106,13 @@ func WithMobTimerDuration(duration time.Duration) func(params *Params) {
 func WithAutoPush(value bool) func(params *Params) {
 	return func(params *Params) {
 		params.AutoPush = value
+	}
+}
+
+// WithGitRemote sets the provided value as the git remote name to be used
+func WithGitRemote(remote string) func(params *Params) {
+	return func(params *Params) {
+		params.GitRemote = remote
 	}
 }
 

--- a/src/vcs/factory/vcs_factory.go
+++ b/src/vcs/factory/vcs_factory.go
@@ -31,7 +31,7 @@ import (
 )
 
 // InitVCS returns the VCS instance of type defined by name, working on the provided directory
-var InitVCS func(name string, dir string) (vcs.Interface, error)
+var InitVCS func(name string, dir string, remoteName string) (vcs.Interface, error)
 
 func init() {
 	// InitVCS is set by default to real VCS implementation factory.
@@ -51,10 +51,10 @@ func (e *UnsupportedVCSError) Error() string {
 }
 
 // initVCS returns the VCS instance of type defined by name, working on the provided directory
-func initVCS(name string, dir string) (vcs.Interface, error) {
+func initVCS(name string, dir string, remoteName string) (vcs.Interface, error) {
 	switch strings.ToLower(name) {
 	case git.Name:
-		return git.New(dir)
+		return git.New(dir, remoteName)
 	case p4.Name:
 		return p4.New(dir)
 	default:

--- a/src/vcs/factory/vcs_factory_test.go
+++ b/src/vcs/factory/vcs_factory_test.go
@@ -31,14 +31,14 @@ import (
 func Test_supported_vcs(t *testing.T) {
 	for _, name := range []string{"git", "p4"} {
 		t.Run(name, func(t *testing.T) {
-			_, err := initVCS(name, "")
+			_, err := initVCS(name, "", "")
 			assert.NotEqual(t, reflect.TypeOf(&UnsupportedVCSError{}), reflect.TypeOf(err))
 		})
 	}
 }
 
 func Test_vcs_factory_returns_an_error_when_vcs_is_not_supported(t *testing.T) {
-	v, err := initVCS("unknown-vcs", "")
+	v, err := initVCS("unknown-vcs", "", "")
 	assert.IsType(t, &UnsupportedVCSError{}, err)
 	assert.Zero(t, v)
 }

--- a/src/vcs/fake/vcs_test_fake.go
+++ b/src/vcs/fake/vcs_test_fake.go
@@ -183,11 +183,6 @@ func (vf *VCSFake) GetRemoteName() string {
 	return vf.remoteName
 }
 
-// SetRemoteName sets the current VCS remote name
-func (vf *VCSFake) SetRemoteName(name string) {
-	vf.remoteName = name
-}
-
 // GetWorkingBranch returns the current VCS working branch
 func (vf *VCSFake) GetWorkingBranch() string {
 	return "vcs-fake-working-branch"

--- a/src/vcs/fake/vcs_test_fake.go
+++ b/src/vcs/fake/vcs_test_fake.go
@@ -75,6 +75,7 @@ type (
 	VCSFake struct {
 		settings           Settings
 		pushEnabled        bool
+		remoteName         string
 		lastCommands       []Command
 		lastCommitSubjects []string
 	}
@@ -91,7 +92,12 @@ func (vf *VCSFake) fakeCommand(cmd Command) (err error) {
 // NewVCSFake initializes a fake VCS implementation which does nothing
 // apart from emulating errors on VCS operations
 func NewVCSFake(settings Settings) *VCSFake {
-	return &VCSFake{settings: settings, lastCommitSubjects: make([]string, 0), lastCommands: make([]Command, 0)}
+	return &VCSFake{
+		settings:           settings,
+		remoteName:         "vcs-fake-remote-name",
+		lastCommitSubjects: make([]string, 0),
+		lastCommands:       make([]Command, 0),
+	}
 }
 
 // Name returns VCS name
@@ -174,7 +180,12 @@ func (vf *VCSFake) GetRootDir() string {
 
 // GetRemoteName returns the current VCS remote name
 func (vf *VCSFake) GetRemoteName() string {
-	return "vcs-fake-remote-name"
+	return vf.remoteName
+}
+
+// SetRemoteName sets the current VCS remote name
+func (vf *VCSFake) SetRemoteName(name string) {
+	vf.remoteName = name
 }
 
 // GetWorkingBranch returns the current VCS working branch

--- a/src/vcs/git/git_impl.go
+++ b/src/vcs/git/git_impl.go
@@ -190,6 +190,11 @@ func (g *gitImpl) GetRemoteName() string {
 	return g.remoteName
 }
 
+// SetRemoteName sets the current git remote name
+func (g *gitImpl) SetRemoteName(name string) {
+	g.remoteName = name
+}
+
 // IsRemoteEnabled indicates if git remote operations are enabled
 func (g *gitImpl) IsRemoteEnabled() bool {
 	return g.remoteEnabled

--- a/src/vcs/git/git_impl_test.go
+++ b/src/vcs/git/git_impl_test.go
@@ -699,6 +699,24 @@ func Test_check_remote_access(t *testing.T) {
 	}
 }
 
+func Test_set_remote_name(t *testing.T) {
+	tests := []struct {
+		desc     string
+		name     string
+		expected string
+	}{
+		{desc: "origin", name: "origin", expected: "origin"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			g, _ := newGitImpl(inMemoryRepoInit, "")
+			g.SetRemoteName(test.name)
+			assert.Equal(t, test.expected, g.GetRemoteName())
+		})
+	}
+}
+
 func Test_is_on_root_branch(t *testing.T) {
 	testFlags := []struct {
 		desc     string

--- a/src/vcs/p4/p4_impl.go
+++ b/src/vcs/p4/p4_impl.go
@@ -110,13 +110,8 @@ func (p *p4Impl) GetRootDir() string {
 
 // GetRemoteName returns the current p4 "remote name"
 func (*p4Impl) GetRemoteName() string {
-	// Always return an empty string
+	// Always return an empty string as there is no such thing as a remote in p4
 	return ""
-}
-
-// SetRemoteName sets the current p4 "remote name"
-func (p *p4Impl) SetRemoteName(_ string) {
-	// This method does nothing in the case of p4
 }
 
 // IsRemoteEnabled indicates if p4 remote operations are enabled

--- a/src/vcs/p4/p4_impl.go
+++ b/src/vcs/p4/p4_impl.go
@@ -114,6 +114,11 @@ func (*p4Impl) GetRemoteName() string {
 	return ""
 }
 
+// SetRemoteName sets the current p4 "remote name"
+func (p *p4Impl) SetRemoteName(_ string) {
+	// This method does nothing in the case of p4
+}
+
 // IsRemoteEnabled indicates if p4 remote operations are enabled
 // remote is always enabled with p4 due its architecture (all changes occur directly on the server)
 func (*p4Impl) IsRemoteEnabled() bool {

--- a/src/vcs/vcs.go
+++ b/src/vcs/vcs.go
@@ -53,6 +53,7 @@ type Interface interface {
 	SessionSummary() string
 	GetRootDir() string
 	GetRemoteName() string
+	SetRemoteName(name string)
 	GetWorkingBranch() string
 	IsOnRootBranch() bool
 	Add(paths ...string) error

--- a/src/vcs/vcs.go
+++ b/src/vcs/vcs.go
@@ -53,7 +53,6 @@ type Interface interface {
 	SessionSummary() string
 	GetRootDir() string
 	GetRemoteName() string
-	SetRemoteName(name string)
 	GetWorkingBranch() string
 	IsOnRootBranch() bool
 	Add(paths ...string) error


### PR DESCRIPTION
# Description:
Adding of a new command-line option -g (or --git-remote) allowing to use a different git remote name than "origin",
which was up to now hard-coded inside the tool.

- "origin" is still used as the default git remote name when this new option is not used, so that current behaviour remain the same as before 
- the git remote name being user (and repository)-specific, TCR does not save it in its configuration file, so that multiple users mobbing with TCR can still collaborate even if they use different git remote names. This implies that users using a specific git-remote name must specify it through the command line every time when launching TCR on the concerned repository. 

Fixes #37 

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [x] New feature

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
