### PR TITLE
Add introspective variant support for Perforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ provided as built-in.
 
 ### TCR Variants
 
-TCR tool can run several variants of the TCR workflow, inspired by [this blog post](https://medium.com/@tdeniffel/tcr-variants-test-commit-revert-bf6bd84b17d3)
+TCR tool can run several variants of the TCR workflow, inspired
+by [this blog post](https://medium.com/@tdeniffel/tcr-variants-test-commit-revert-bf6bd84b17d3)
 by Thomas Deniffel.
 
 Some are great as pedagogic tools, some are better for day-to-day use.
@@ -245,13 +246,22 @@ Before running TCR with Perforce, make sure that the P4 Client is properly confi
 To use TCR with Perforce, you'll need to add the `--vcs=p4` to the command line (you can also set this up in
 the `.tcr/config.yml`, see the [Configuration Directory](#configuration-directory) section below).
 
+> ***Note: IDE configuration when using TCR with Perforce***
+>
+> In order to use TCR with Perforce, make sure to setup your IDE so that it
+> automatically marks files for edit on modify. Without this you will still be able to use TCR,
+> but you will have to repeatedly mark files for edit after every commit.
+>
+> - With VS-Code, look for available Perforce extensions to enable it
+> - With JetBrains IDEs, [Perforce Helix Core](https://plugins.jetbrains.com/plugin/69-perforce-helix-core) plugin
+    allows to enable it
+
 > ***Note: Perforce limitations***
 >
 > At the moment, TCR over Perforce is still in the experimentation phase. It does not yet support all the options
 > available with git.
 > Here are the main limitations:
 >
-> - Option `--commit-failures` or `-f` is not supported
 > - Option `--auto-push` or `-p` has no meaning with Perforce and is ignored
 > - Sub-command `log` is not supported
 > - Sub-command `stats` is not supported

--- a/README.md
+++ b/README.md
@@ -246,25 +246,39 @@ Before running TCR with Perforce, make sure that the P4 Client is properly confi
 To use TCR with Perforce, you'll need to add the `--vcs=p4` to the command line (you can also set this up in
 the `.tcr/config.yml`, see the [Configuration Directory](#configuration-directory) section below).
 
-> ***Note: IDE configuration when using TCR with Perforce***
->
-> In order to use TCR with Perforce, make sure to setup your IDE so that it
-> automatically marks files for edit on modify. Without this you will still be able to use TCR,
-> but you will have to repeatedly mark files for edit after every commit.
->
-> - With VS-Code, look for available Perforce extensions to enable it
-> - With JetBrains IDEs, [Perforce Helix Core](https://plugins.jetbrains.com/plugin/69-perforce-helix-core) plugin
-    allows to enable it
+##### Ignoring intermediate files
 
-> ***Note: Perforce limitations***
->
-> At the moment, TCR over Perforce is still in the experimentation phase. It does not yet support all the options
-> available with git.
-> Here are the main limitations:
->
-> - Option `--auto-push` or `-p` has no meaning with Perforce and is ignored
-> - Sub-command `log` is not supported
-> - Sub-command `stats` is not supported
+As TCR automatically submits everything that changed since last submit,
+you might end up with binary and/or build files in the depot.
+
+To prevent this from happening, you
+can [set up Perforce to ignore them](https://www.perforce.com/manuals/cmdref/Content/CmdRef/P4IGNORE.html).
+
+In practice, we found that you can use the same setting as with git:
+
+```shell
+p4 set P4IGNORE=.gitignore
+```
+
+##### IDE configuration when using TCR with Perforce
+
+In order to use TCR with Perforce, make sure to setup your IDE so that it
+automatically marks files for edit on modify. Without this you will still be able to use TCR,
+but you will have to repeatedly mark files for edit after every commit.
+
+- With VS-Code, look for available Perforce extensions to enable it
+- With JetBrains IDEs, [Perforce Helix Core](https://plugins.jetbrains.com/plugin/69-perforce-helix-core) plugin
+  allows to enable it
+
+##### Perforce limitations
+
+At the moment, TCR over Perforce is still in the experimentation phase. It does not yet support all the options
+available with git.
+Here are the main limitations:
+
+- Option `--auto-push` or `-p` has no meaning with Perforce and is ignored
+- Sub-command `log` is not supported
+- Sub-command `stats` is not supported
 
 </details>
 

--- a/src/vcs/p4/p4_impl.go
+++ b/src/vcs/p4/p4_impl.go
@@ -175,12 +175,12 @@ func (p *p4Impl) RevertLocal(path string) error {
 }
 
 // RollbackLastCommit runs a p4 revert operation.
-func (*p4Impl) RollbackLastCommit() error {
-	// TO IMPLEMENT
-	// get the changelist to rollback "p4 changes -m1 @<client_name>"
-	// undo this changelist "p4 undo @,@"
-	// no commit to do,  will be called by TCR
-	return errors.New("VCS revert operation not yet available for p4")
+func (p *p4Impl) RollbackLastCommit() error {
+	cl, err := p.getLatestChangelist()
+	if err != nil {
+		return err
+	}
+	return p.undoChangelist(*cl)
 }
 
 // Push runs a push operation.

--- a/src/vcs/p4/p4_impl.go
+++ b/src/vcs/p4/p4_impl.go
@@ -352,7 +352,7 @@ func (p *p4Impl) toP4ClientPath(dir string) (string, error) {
 }
 
 func (p *p4Impl) getLatestChangelistId() (*changeList, error) {
-	p4Output, err := p.runP4("changes", "-m1", p.clientName, "-s", "submitted")
+	p4Output, err := p.runP4("changes", "-m1", "@"+p.clientName, "-s", "submitted")
 	if err != nil {
 		return nil, err
 	}

--- a/src/vcs/p4/p4_impl.go
+++ b/src/vcs/p4/p4_impl.go
@@ -175,6 +175,10 @@ func (p *p4Impl) RevertLocal(path string) error {
 
 // RollbackLastCommit runs a p4 revert operation.
 func (*p4Impl) RollbackLastCommit() error {
+	// TO IMPLEMENT
+	// get the changelist to rollback "p4 changes -m1 @<client_name>"
+	// undo this changelist "p4 undo @,@"
+	// no commit to do,  will be called by TCR
 	return errors.New("VCS revert operation not yet available for p4")
 }
 
@@ -275,6 +279,9 @@ func (p *p4Impl) buildP4Args(args ...string) []string {
 
 func (p *p4Impl) createChangeList(messages ...string) (*changeList, error) {
 	// Command: p4 --field "Description=<message>" change -o | p4 change -i
+	//   `change -o` outputs a "changelist spec" to stdout
+	//   `change -i` then reads it and creates a real changelist from it
+	//   `change -o` takes all the changed files from the Default changelist and adds them to this new changelist
 	out, err := p.runPipedP4(newP4Command(p.buildP4Args("change", "-i")...),
 		"-Q", "utf8",
 		"--field", buildDescriptionField(shell.GetAttributes(), messages...),

--- a/src/vcs/p4/p4_impl.go
+++ b/src/vcs/p4/p4_impl.go
@@ -351,7 +351,7 @@ func (p *p4Impl) toP4ClientPath(dir string) (string, error) {
 	return "//" + p.clientName + slashedPath + "...", nil
 }
 
-func (p *p4Impl) getLatestChangelistId() (*changeList, error) {
+func (p *p4Impl) getLatestChangelist() (*changeList, error) {
 	p4Output, err := p.runP4("changes", "-m1", "@"+p.clientName, "-s", "submitted")
 	if err != nil {
 		return nil, err
@@ -363,4 +363,9 @@ func (p *p4Impl) getLatestChangelistId() (*changeList, error) {
 	}
 
 	return &changeList{fields[1]}, nil
+}
+
+func (p *p4Impl) undoChangelist(changelist changeList) error {
+	err := p.traceP4("undo", fmt.Sprintf("@%v,@%v", changelist.number, changelist.number))
+	return err
 }

--- a/src/vcs/p4/p4_impl_test.go
+++ b/src/vcs/p4/p4_impl_test.go
@@ -611,7 +611,7 @@ func Test_p4_get_latest_changelist_id(t *testing.T) {
 			"Change 7297330 on 2024/10/01 by pbourgau@pbourgau_LPBOU05_8775 'Γ£à TCR - tests passing  cha'",
 			nil,
 			false,
-			[]string{"changes", "-m1", p4TestClientName, "-s", "submitted"},
+			[]string{"changes", "-m1", "@" + p4TestClientName, "-s", "submitted"},
 			&changeList{"7297330"},
 		},
 		{"p4 changes return an error",


### PR DESCRIPTION
# Description:
Add support of introspective variant for Perforce
- Add function for retrieval of last change list id (using "p4 changes" command)
- Add call to "p4 undo" command
- Wrap them into implementation of p4.RollbackLastCommit()
- Enrich README with Perforce-specific recommendations for ignoring files and setting up the IDE for auto-marking files for edit

Fixes #791 

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [x] New feature

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
