### PR TITLE
[#928] Bump go from 1.23 to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
           cache-dependency-path: src/go.mod
 

--- a/.github/workflows/go_releaser.yml
+++ b/.github/workflows/go_releaser.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
           cache-dependency-path: src/go.mod
       - name: Setup node.js

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -10,7 +10,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [ '1.23' ]
+        go: [ '1.24' ]
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
   disable:
     - goimports
 run:
-  go: "1.23"
+  go: "1.24"
   timeout: 5m
 linters-settings:
   gocyclo:

--- a/dev-doc/build.md
+++ b/dev-doc/build.md
@@ -14,7 +14,7 @@ cd TCR
 
 TCR is written in Go. This implies having Go compiler and tools installed on your machine.
 
-Simply follow the instructions provided [here](https://go.dev/). Make sure to install **Go version 1.23** or higher.
+Simply follow the instructions provided [here](https://go.dev/). Make sure to install **Go version 1.24** or higher.
 
 ## Install additional Go tools and utility packages
 

--- a/examples/go-bazel/go.mod
+++ b/examples/go-bazel/go.mod
@@ -1,6 +1,6 @@
 module example/go-bazel
 
-go 1.23.3
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/examples/go-go-tools/go.mod
+++ b/examples/go-go-tools/go.mod
@@ -1,6 +1,6 @@
 module example/go-go-tools
 
-go 1.23.3
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/examples/go-gotestsum/go.mod
+++ b/examples/go-gotestsum/go.mod
@@ -1,6 +1,6 @@
 module example/go-gotestsum
 
-go 1.23.3
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/examples/go-make/go.mod
+++ b/examples/go-make/go.mod
@@ -1,6 +1,6 @@
 module example/go-make
 
-go 1.23.3
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/examples/go.work
+++ b/examples/go.work
@@ -1,4 +1,4 @@
-go 1.23.3
+go 1.24.0
 
 use (
 	go-bazel

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/murex/tcr
 
-go 1.23.4
+go 1.24.0
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect

--- a/tcr-doc/go.mod
+++ b/tcr-doc/go.mod
@@ -1,6 +1,6 @@
 module github.com/murex/tcr/tcr-doc
 
-go 1.23.4
+go 1.24.0
 
 replace github.com/murex/tcr => ../src
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5771,9 +5771,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.24.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.1.tgz",
-      "integrity": "sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+      "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5855,17 +5855,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.24.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.1.tgz",
-      "integrity": "sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+      "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.24.1",
-        "@typescript-eslint/types": "8.24.1",
-        "@typescript-eslint/typescript-estree": "8.24.1"
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5880,15 +5880,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.24.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.1.tgz",
-      "integrity": "sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+      "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.24.1",
-        "@typescript-eslint/visitor-keys": "8.24.1"
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5899,15 +5899,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.24.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.1.tgz",
-      "integrity": "sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+      "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.24.1",
-        "@typescript-eslint/visitor-keys": "8.24.1",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5927,14 +5927,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.24.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.1.tgz",
-      "integrity": "sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+      "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/types": "8.25.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {


### PR DESCRIPTION
# Description:

Bump go from 1.23 to 1.24 in both TCR and go examples

Fixes #928 

## Type of change
Please tick the appropriate option using [x]

- [ ] Bug fix
- [ ] New feature
- [x] Tooling and Environment

# Checklist:
Please tick the appropriate options using [x]

- [x] My PR includes tests that cover my code changes.
- [x] Lint and formatter run with no errors
- [x] All new and old tests are passing
